### PR TITLE
Fix related links on 2025-02-28_FOSS4G-bg.md

### DIFF
--- a/content/posts/2025-02-28_FOSS4G-bg.md
+++ b/content/posts/2025-02-28_FOSS4G-bg.md
@@ -9,7 +9,8 @@ description: "FOSS4G:BG: Open GIS conference is coming early in March as a local
 icon: material/chat
 license: beerware
 links:
-  - qgis.bg website: https://qgisbg.github.io/docs/meta/1110_qgisbg_docs_setup_windows/
+  - QGIS.bg website: https://qgisbg.github.io
+  - FOSS4G:BG page: https://foss4g.github.io
 pin: false
 tags:
     - Bulgaria


### PR DESCRIPTION
Just fixing a link pointing to a random "How to install qgis.bg on windows" page.